### PR TITLE
Document that nssock/nsssl is required for ns_connchan, Layout changes.

### DIFF
--- a/doc/src/man.css
+++ b/doc/src/man.css
@@ -101,7 +101,9 @@ dl dt {
    max-width:    50em;
 }
 
-
+dd>dl.doctools_options {
+    margin-left: 2em;
+}
 .sample {
    background-color: #f9f6f6;
    margin-left: 0;

--- a/doc/src/naviserver/ns_connchan.man
+++ b/doc/src/naviserver/ns_connchan.man
@@ -159,29 +159,38 @@ connections. On success, this command returns a dict containing
 "channel", "port", "sock" and "address".
 
 
-[call [cmd "ns_connchan open"] \
-	[opt [option "-headers [arg h]"]] \
-	[opt [option "-hostname [arg HOSTNAME ]"]] \
-	[opt [option "-method [arg m]"]] \
-	[opt [option "-timeout [arg t]"]] \
-	[opt [option "-version [arg v]"]] \
-	[arg url] \
-]
+[call [cmd "ns_connchan open"] [opt [arg options]] [arg url]]
 
-Open a connection channel to the specified [arg url].
-The URL might be an HTTP or an HTTPS URL.
-[option -headers] refers to a [term ns_set] of request header fields,
-[option -method] specifies the HTTP method (default GET),
-[option -timeout] specifies the timeout for establishing the connection
-(default 1 second), and
-[option -version] specifies the HTTP version (default 1.0)
-The timeout value [arg t] is specified in the form
-[arg secs[opt :microseconds]], or [arg secs.fraction],
-or as a number with a time unit.
+[para]
+Open a connection channel to the specified [arg url].  The URL can
+either be an HTTP or an HTTPS URL.  The [term driver] for the protocol
+of the [arg url] must be loaded: [term nssock] for HTTP, [term nsssl]
+for HTTPS.  A driver can be loaded without configuring a socket for it
+by setting the [option port] to [const 0].
 
-For connecting to a server with virtual hosting that provides
-multiple certificates via SNI (Server Name Indication) the
-option [option -hostname] is required.
+[para]
+The [arg options] can be any of:
+
+[para]
+[list_begin options]
+[opt_def -headers [arg headers]] A [type [term ns_set]] of request header
+fields.
+
+[opt_def -hostname [arg hostname]] Required for connecting to a
+server with virtual hosting that provides multiple certificates via
+SNI (Server Name Indication).
+
+[opt_def -method [arg method]] Specifies the HTTP method, by default
+[const GET].
+
+[opt_def -timeout [arg timeout]] Specifies the timeout for
+establishing the connection, by default 1 second. The timeout value
+[arg timeout] is specified in the form [arg secs[opt :microseconds]],
+or [arg secs.fraction], or as a number with a time unit.
+
+[opt_def -version [arg HTTP_version]] Specifies the HTTP version,
+by default [const 1.0]
+[list_end]
 
 
 [call [cmd "ns_connchan read"] \
@@ -204,9 +213,6 @@ Tcl [cmd dict] containing the following elements:
 [term haveData] (boolean value to express that unprocessed
 data might be sufficient for the next frame without an extra read
 operation.
-
-
-
 
 [para]
 In case the frame is finished ([term fin] status bit is set),
@@ -275,7 +281,7 @@ this with potentially more data from other write operations.
 
 [list_end]
 
-[see_also ns_conn ns_chan ns_sockcallback ns_write ns_time]
+[see_also ns_conn ns_chan ns_sockcallback ns_write ns_time nssock nsssl]
 [keywords "server built-in" channels socket driver reverseproxy websocket]
 
 [manpage_end]


### PR DESCRIPTION
`ns_connchan open`_url_ requires the respective driver loaded for the _url_'s protocol.

Besides adding this requirement to the `ns_connchan` man page, this commit rewrites the `ns_connchan open` entry to use an `options` list and adds left-margin to nested `opt_def` lists so they align with `para`graphs.