### PR TITLE
Remove restriction on virtual host, that pagedir should be a relative path

### DIFF
--- a/nsd/pathname.c
+++ b/nsd/pathname.c
@@ -88,12 +88,6 @@ ConfigServerVhost(const char *server)
         path = Ns_ConfigGetPath(server, NULL, "vhost", (char *)0L);
 
         servPtr->vhost.enabled = Ns_ConfigBool(path, "enabled", NS_FALSE);
-        if (servPtr->vhost.enabled
-            && Ns_PathIsAbsolute(servPtr->fastpath.pagedir) == NS_TRUE) {
-            Ns_Log(Error, "vhost[%s]: disabled, pagedir not relative: %s",
-                   server, servPtr->fastpath.pagedir);
-            servPtr->vhost.enabled = NS_FALSE;
-        }
         if (Ns_ConfigBool(path, "stripwww", NS_TRUE)) {
             servPtr->vhost.opts |= NSD_STRIP_WWW;
         }


### PR DESCRIPTION
On our installation, we are de-facto using virtual hosts, as the application will reply to multiple domain names. However, we have so far never setup vhost configuration, e.g. the one via:

`ns_section ns/server/${server}/vhost`

Because we run behind a proxy, we do set proxy mode, e.g. via:

`ns_section ns/parameters/reverseproxymode`

This has been working fine so far. However, since change in https://github.com/naviserver-project/naviserver/commit/cc6782a73d0e761a3a8b2ec208e6b7f56834c904, ns_conn location will not return for us the expected hostname, but the empty string.

We believe our configuration may have been incorrect so far, as we did not enable vhost while in fact we use it. This prevent the Host: field by the client from being correctly recognized according to https://naviserver.sourceforge.io/n/naviserver/files/ns_conn.html#30.

Before https://github.com/naviserver-project/naviserver/commit/cc6782a73d0e761a3a8b2ec208e6b7f56834c904, this was working "fine" because we would end into a series of later fallbacks that would eventually return the expected host, but now this is not the case anymore, at least with reverseproxymode activated.

We now tried to enable vhost in our configuration, but we realized this did not take effect because we set pagedir as an absolute path and we trigger the code that I am deleting in this PR. This restriction was introduced by https://github.com/naviserver-project/naviserver/commit/129cdab22d42022db50bf5d1a9060e74a8f9661a

The reason why I think this should go away is that other servers, such as Apache, do not seem to have this restriction (see e.g. https://httpd.apache.org/docs/current/vhosts/name-based.html). If we need to stick with relative paths, we will probably need something on the line of symlinks in the NaviServer directory.

I will gladly provide more information on the specific issue, if needed.

All the best
