### PR TITLE
Fix cosmetic issue on displaying nsperm message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ install-config: all
 	@for i in returnnotice.adp nsd-config.tcl sample-config.tcl simple-config.tcl openacs-config.tcl ; do \
 		$(INSTALL_DATA) $$i $(DESTDIR)$(NAVISERVER)/conf/; \
 	done
-	@for i in index.adp install-from-repository.tcl; do \
+	@for i in index.adp default.css install-from-repository.tcl; do \
 		$(INSTALL_DATA) $$i $(DESTDIR)$(NAVISERVER)/pages/; \
 	done
 	$(INSTALL_SH) install-sh $(DESTDIR)$(INSTBIN)/

--- a/default.css
+++ b/default.css
@@ -1,0 +1,230 @@
+   /* Additional Colors */
+    :root {
+        --color-security-bg: #fff3cd;
+        --color-security-strong: #856404;
+        --color-security-border: #ffeeba;
+        --color-action-btn-bg: #007BFF;   /* a brighter blue variant */
+        --color-action-btn-text: #fff;
+        --color-header-naviserver: var(--color-white);
+    }
+
+    .main_header_blue {
+ display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+  background: #d9872d
+
+    }
+
+    @media (prefers-color-scheme: dark) {
+        :root {
+            --color-security-bg: #6a4e00a6; /*#6A4E00;*/
+            --color-security-strong: #ffd966bf; /*#ffd966;*/
+            --color-security-border: #8C6400;
+            --color-action-btn-bg: #66B3FF;
+            --color-action-btn-text: #002347;
+            --color-header-naviserver: var(--color-anchor);
+        }
+    }
+
+    body { font-family: Arial, sans-serif; /*background: #f9f9f9; */ margin: 0; padding: 0; }
+    header { background: var(--color-primary-blue); padding: 20px; color: var(--color-white); }
+    header a { color: var(--color-header-naviserver); text-decoration: none; font-size: 1.5em; }
+    header a:hover {color: var(--color-header-naviserver);}
+    header span.tagline { font-size: 1em; margin-left: 10px; }
+    .display {
+        padding: 20px;
+        margin-left: auto;
+        margin-right: auto;
+        color: var(--color-body-text);
+    }
+    @media (min-width: 576px) { .display {max-width: 540px; }}
+    @media (min-width: 768px) { .display {max-width: 720px; }}
+    @media (min-width: 992px) { .display {max-width: 960px; }}
+    @media (min-width: 1200px) {.display {max-width: 1100px;}}
+    .external::after {
+      content: "↗";
+      font-size: 0.7em;
+      vertical-align: super;
+      margin-left: 0px;
+      /*color: #666;*/
+    }
+
+    ul { list-style-type: disc; margin-top: 0px; margin-left: 20px; padding-left: 2rem;}
+    p {margin-top: 0px; margin-bottom: 1rem;}
+
+    .config_details li { margin-bottom: 8px; }
+    .security {
+        background: var(--color-security-bg);
+        border: 1px solid var(--color-security-border);
+        padding: 10px;
+        margin-top: 20px;
+    }
+    .security strong {
+        color: var(--color-security-strong);
+    }
+    .security_icon {
+        vertical-align: -0.25em;
+    }
+    .security_icon .exclamation {
+        stroke: var(--color-security-bg);
+        fill: var(--color-security-bg);
+    }
+
+    .btn_action {
+      display: inline-block;
+      text-decoration: none;
+      border-radius: 4px;
+      font-weight: bold;
+      font-size: 16px;
+      transition: background-color 0.3s ease, transform 0.2s ease;
+    }
+
+    button#changePwdBtn.btn_action {
+      padding: 6px 10px;
+      margin-left: 15px;
+      background-color: #f0f0f0;
+      color: #007BFF;
+    }
+
+    .btn_action:hover, .btn-action:focus {
+      /*background-color: #0056b3; *//* A slightly darker blue for hover state */
+      transform: translateY(-2px); /* lift effect */
+    }
+
+    div.display h1 {
+      font-size: 2.5rem;          /* Large, prominent size */
+      /*color: #333; */               /* Dark grey for excellent readability */
+      font-weight: 700;           /* Bold to draw attention */
+      margin-top: 2.5rem;         /* Generous spacing above */
+      margin-bottom: 1.5rem;      /* A little spacing below */
+      line-height: 1.2;           /* Tighter line spacing for impact */
+    }
+    div.display h2 {
+      font-size: 1.8rem;          /* Slightly smaller than h1 */
+      /*color: #004080;*/             /* Using the same blue as the header for brand consistency */
+      font-weight: 600;           /* Semi-bold for prominence */
+      margin-top: 1.5rem;           /* Adequate spacing above */
+      margin-bottom: 0.5rem;      /* Consistent spacing below */
+      padding-bottom: 0.25rem;    /* Space for the underline */
+      border-bottom: 2px solid var(--color-border);  /* Subtle underline to separate sections */
+      line-height: 1.2;
+    }
+    @media (prefers-color-scheme: light) {
+        div.display h1 {
+            color: #333;
+        }
+        div.display h2 {
+            color: #004080;
+        }
+    }
+    @media (prefers-color-scheme: dark) {
+        div.display h1 {
+            color: var(--color-header-strong-text);
+        }
+        div.display h2 {
+            color: var(--color-header-strong-text);
+        }
+    }
+    @media (max-width: 768px) {
+        div.display h1 {font-size: 2.0rem;}
+    }
+
+  .right_align {
+    text-align: right; /* Align the content of this cell to the right */
+  }
+
+    /* Modal overlay */
+    .modal {
+      display: none;
+      position: fixed;
+      z-index: 1000;
+      left: 0;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      overflow: auto;
+      background-color: rgba(0,0,0,0.4);
+    }
+    /* Modal content box */
+    .modal-content {
+      background-color: var(--color-body-bg);
+      margin: 10% auto;
+      padding: 20px;
+      border: 1px solid #888;
+      width: 300px;
+      border-radius: 5px;
+    }
+    .display .modal-content h2 {
+      margin-top: 0.1rem;
+    }
+    /* Close button */
+    .close {
+      /*color: #aaa;*/
+      float: right;
+      font-size: 28px;
+      font-weight: bold;
+      cursor: pointer;
+    }
+.close:hover,
+.close:focus {
+  /*color: black;*/
+}
+
+.code #terminal {
+    font-weight: bold;
+}
+.code #general {
+
+}
+
+label {
+  display: block;
+  margin-top: 10px;
+  font-weight: bold;
+}
+
+input[type="password"] {
+  width: 100%;
+  padding: 8px;
+  margin: 5px 0;
+  box-sizing: border-box;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.container {
+    width: 100%; /* Ensure the container takes the full width */
+    box-sizing: border-box; /* Include padding and border in the element's total width and height */
+}
+
+table {
+    width: 100%; /* Ensure the table takes the full width of the container */
+    border-collapse: collapse; /* Remove spacing between table cells */
+}
+
+td {
+    padding: 10px; /* Add some padding to the table cells */
+    border: 1px solid #ddd; /* Add a border to the table cells */
+}
+
+.icon_cell {
+    width: 50px; /* Set a fixed width for the icon cell */
+    text-align: center; /* Center the icon within the cell */
+    vertical-align: middle; /* Vertically center the icon within the cell */
+}
+
+.icon_class {
+    font-size: 24px; /* Set the size of the icon */
+    color: #333; /* Set the color of the icon */
+}
+
+.right_align {
+    text-align: right; /* Align the content of this cell to the right */
+}
+
+.modal_content .btn_action {
+        font-size: larger;
+        margin: 10px 0px 0px 0px;
+ }

--- a/index.adp
+++ b/index.adp
@@ -1,76 +1,125 @@
-<!--
-    ;# Welcome to the upper terrority of an *.adp file,
-    ;#  As you scroll through this page looking in confusion, you may find it intriguring
-    ;#  Take a breath and start from the top
-    ;#    The first procedure is commented, see if you can tag along :-)
---!>
 <%
-  ;#  We wish to safeguard this procedure, using try enables us to catch any errors
-  ;#  the command "proc" constructs a foundation for the procedure named probe_driver_info
-  ;#    the { } defines our information gates
-  ;##   This is where information can be passed within
-  ;#      In this case, we construct the gate "opt" short-hand for option, for our option menu below
-try { proc probe_driver_info {opt} {
-    ;# we've now created our procedure, well done.
-    ;# the pillars are up but we have no working sand
-    ;# so let's start
+  ;# Welcome to the upper terrority of an *.adp file,
+  ;#  As you scroll through this page looking in confusion, you may find it intriguring
+  ;#  Take a breath and start from the top
+  ;#    The first procedure is commented, see if you can tag along :-)
+  ;#
+  ;#  try { }
+  ;#    This is wrapped around our procedure below
+  ;#      this allows us to capture any errors
+  ;#      or store the error in a specifc variable
+  ;#      allowing us to hanlde the error without interuptting the user
+  ;#
+  ;#  proc probe_driver_info {opt} {}
+  ;#    proc is short for procedure
+  ;#      when called it executes code within it's body
+  ;#      we can pass information in to the procedure
+  ;#      in this case we store this information in a variable called "opt"
+  ;#      short-hand for option
 
-      ;# This procedure enables us to evalulate an output of a variable
-        proc debug {enable input} { switch $enable { 1 { puts ">>> $input <<<" } } }
-        debug 0 [ns_driver info]  ;# raw output of the internals information
-        debug 0 [concat {*}[ns_driver info]] ;# we convert our long string of information in to a list
-                                             ;# the list enables us later on to pick and choose which value we desire
-        variable nssock_driver_info [concat {*}[ns_driver info]] ;# all our information we require is currently in one very long string without a fullstop
-        ;# and so lets begin this adventure
-        switch $opt {
-          protocol { ;# Was the protocol passed to the gate?
-            return "<code><strong>protocol:</strong> [dict get $nssock_driver_info protocol]"
-          }
-          address { ;# Or maybe it was a address request
-            ;#  This switch determines if the server is hosted on two IP addresses
-            ;#    cute
-            switch [llength [dict get $nssock_driver_info address]] {
-              1       { return "<code id=\"terminal\">Listening on address:[dict get $nssock_driver_info address]</code>\
-                                at port <code class=\"terminal\"> [dict get $nssock_driver_info port]</code>"  }
-              default { return "<code id=\"terminal\">Listening on addresses:</code> <code id=\"general\">[dict get $nssock_driver_info address]</code> \
-                                at ports <code id=\"general\"> [dict get $nssock_driver_info port]</code>" }
-            }
-          }
-          port { ;# Was it a port?
-            switch [llength [dict get $nssock_driver_info address]] {
-              1       { return "<code id=\"terminal\">Listening at port: <code id=\"general\">[dict get $nssock_driver_info port]</code>" }
-              default { return "<code id=\"terminal\">Listening at ports: <code id=\"general\">[dict get $nssock_driver_info port]</code>" }
-            } ;# end switch
-          }
-          os { ;# maybe an os?
-            return "<code id=\"terminal\">Operating System:</code> <code>$::tcl_platform(os) $::tcl_platform(osVersion)</code>"
-          }
-          modules { ;# show me the shades
-            variable modules [ns_ictl getmodules]
-            variable modules [append modules "[nsv_dict get system modules_enabled live]"]
+try {
+  proc probe_driver_info {opt} {
+    ;# we've now created our first procedure, well done.
 
-            return "<code id=\"terminal\">Modules Available:</code> <code id=\"general\">$modules</code>"
+    ;# We construct a second procedure for simple debugging
+    ;#  This procedure has two variables: "enable" and "input"
+    ;#  enable - allows us if we wish to display the debug out or not
+    ;#  input  - displays the data passed to the procedure
+    proc debug {enable input} { switch $enable { 1 { puts ">>> $input <<<" } } }
+    ;# Examples
+    debug 0 [ns_driver info]  ;# Display the raw output of NaviServer's internal information
+    debug 0 [concat {*}[ns_driver info]]  ;# The above output is very long
+                                          ;# Concat collapses the data in from a long string of information in to a list
+                                          ;# this list enables us later on to pick and choose which value we desire
+                                          ;# Enable to see the results :)
+
+    ;# Hold our driver information in to a list
+    variable nssock_driver_info [concat {*}[ns_driver info]]
+
+    ;# Our variables to hold our bound addresses and ports
+    variable bound_to           [dict get $nssock_driver_info address]
+    variable at_port            [dict get $nssock_driver_info port]
+
+    ;# Navi Instance Version
+    variable navi_version       [ns_info patchlevel]
+
+    ;# Operating System & Version
+    variable operating_system         $::tcl_platform(os)
+    variable operating_system_version $::tcl_platform(osVersion)
+
+    ;# Lets begin this adventure with our first switch
+    ;#  Switch: $opt       - What option did we decide to call
+    ;#    Case: address      - Execute the code within our address case       - Display the address from our driver information variable
+    ;#    Case: modules      - Execute the code within our modules case       - Display the loaded modules
+    ;#    Case: navi_version - Execute the code within our navi_version case  - Display NaviServer's version
+    ;#    Case: port         - Execute the code within our port case          - Display the bound ports that NaviServer sits upon
+    ;#    Case: protocol     - Execute the code within our address case       - Display the working protocol
+    ;#    Case: os           - Execute the code within our address case       - Display our Operating System
+
+    switch $opt {
+      address { ;# We need to differate between "Address" and "Addresses" in case of when the Navi instance is bound to one or more IP
+        ;#  Switch: [llength $bound_to]                                      - Retrieve the bound address(es) from the server configuration
+        ;#                                                                        check to see if we have multiple bound addresses
+        ;#  Case: 1      - We only have one entry for the bound address       - Display "Listen on Address"
+        ;#  Case default - We have two or more bound addresses                - Display "Listen on Addresss"
+        switch [llength $bound_to] {
+          1       {
+            return \
+              "<code id=\"terminal\">Listening on address: $bound_to</code> \
+              at port <code class=\"terminal\"> $at_port</code>"
           }
-          navi_version { ;# Your navi's version code
-            return "<code id=\"terminal\">NaviServer Version:</code> <code id=\"general\">[ns_info patchlevel]</code>"
+          default {
+            return \
+              "<code id=\"terminal\">Listening on addresses:</code> \
+              <code id=\"general\">$bound_to</code> \
+              at ports <code id=\"general\"> $at_port</code>"
           }
-        } ;# end switch option
-      } ;# end proc
+        } ;# end switch llength
+      }
+
+      modules { ;# Show me the shades, return our modules
+        variable modules [ns_ictl getmodules]
+        variable modules [append modules "[nsv_dict get system modules_enabled live]"]
+        #
+        return \
+          "<code id=\"terminal\">Modules Available:</code> <code id=\"general\">$modules</code>"
+      }
+
+      navi_version { ;# Hey it's me Navi, return our version number
+        return \
+          "<code id=\"terminal\">NaviServer Version:</code> <code id=\"general\">$navi_version</code>"
+      }
+
+      port { ;# What ports are we bound on?
+        switch [llength [dict get $nssock_driver_info port]] {
+          1       { return "<code id=\"terminal\">Listening at port: <code id=\"general\">$at_port</code>" }
+          default { return "<code id=\"terminal\">Listening at ports: <code id=\"general\">$at_port</code>" }
+        } ;# end switch
+      }
+
+      protocol { ;# And our protocol is?
+        return \
+          "<code><strong>protocol:</strong> [dict get $nssock_driver_info protocol]"
+      }
+
+      os { ;# Finally tell Tcl to tell us our OS Version
+        return \
+          "<code id=\"terminal\">Operating System:</code> <code>$operating_system $operating_system_version</code>"
+      }
+    } ;# end switch option
+  } ;# end proc
 } ;# end try
 
 proc probe_nsstats {} {
   try {
-    ;# Check to see if our file exists
-    variable ns_stats_existence [file exists [ns_server pagedir]/nsstats.tcl]
-    #
     nsv_dict set nsstats text not_installed {Module nsstats was not detected <a href="extras/?package=nsstats" class="btn-action">Install It Now</a>}
     nsv_dict set nsstats text installed {Explore the <a href="/nsstats.tcl"> the Navi Statistics Module</a> for real-time performance insights and logging analysis }
-    #
-  ;# return the following dictonary
+    ;# Check to see if our file exists
+    variable ns_stats_existence [file exists [ns_server pagedir]/nsstats.tcl]
+
     switch $ns_stats_existence {
-      1 { append modules "\u00A0" ;# append a space to the front of our string
+      1 { append modules "\u00A0" ;# append in unicode a whitespace to the front of our string
           append modules "nsstats"
-          ;# include a front facing whitespace
           nsv_dict set system modules_enabled live "$modules"
           return [nsv_dict get nsstats text installed] }
       0 { return [nsv_dict get nsstats text not_installed] }
@@ -80,8 +129,6 @@ proc probe_nsstats {} {
 
 proc display { args } {
   try {
-
-    # Dictonaries entries for displaying alerts
     nsv_dict set image icon alert { &#9888; }
     nsv_dict set btn_action nsperm passwd_msg {The default system administrator password remains unchanged}
     nsv_dict set btn_action nsperm passwd_resolve {Change System Password Now}
@@ -89,20 +136,22 @@ proc display { args } {
 
     variable display_mode [lindex $args 0] ;# Display mode passed to the procedure
     switch $display_mode {
-        css { return [read [open "[ns_server pagedir]/default.css" r]] }
+        css {
+          return [read [open "/forest/fox/~navi/pages/css/default.css" r]]
+        }
         welcome {
-        ###
-        return [ns_trim -delimiter | {
-        |<div>
-        | <h1>Welcome to your NaviServer</h1>
-        | <p>
-        |   Congratulations – your navi instance is up and running!
-        |   <br>
-        |   This page confirms that the default installation is active.
-        | </p>
-        |</div>
-          }]
-        ###
+          ###
+          return [ns_trim -delimiter | {
+          |<div>
+          | <h1>Welcome to your NaviServer</h1>
+          | <p>
+          |   Congratulations – your navi instance is up and running!
+          |   <br>
+          |   This page confirms that the default installation is active.
+          | </p>
+          |</div>
+            }]
+          ###
       }
       security_advice {
         ###
@@ -118,57 +167,58 @@ proc display { args } {
         |            </td>
         |    </table>
         |</div>
-          }]
+        }]
         ]
         ###
       }
       password_unchanged {
-      ###
-      return [ns_trim -delimiter | [subst {
-      |<div class="security">
-      |    <table>
-      |        <tr>
-      |            <td class="icon_cell">
-      |            [nsv_dict get image icon alert]
-      |            </td>
-      |            <td>
-      |            [nsv_dict get btn_action nsperm passwd_msg]
-      |            </td>
-      |        </tr>
-      |        <tr>
-      |            <td class="icon_cell"></td> <!-- Empty icon cell for the second row -->
-      |            <td class="right_align">
-      |                <button id="changePwdBtn" class="btn_action">[nsv_dict get btn_action nsperm passwd_resolve]</button>
-      |            </td>
-      |        </tr>
-      |    </table>
-      |</div>
+        ###
+        return [ns_trim -delimiter | [subst {
+        |<div class="security">
+        |    <table>
+        |        <tr>
+        |            <td class="icon_cell">
+        |            [nsv_dict get image icon alert]
+        |            </td>
+        |            <td>
+        |            [nsv_dict get btn_action nsperm passwd_msg]
+        |            </td>
+        |        </tr>
+        |        <tr>
+        |            <td class="icon_cell"></td> <!-- Empty icon cell for the second row -->
+        |            <td class="right_align">
+        |                <button id="changePwdBtn" class="btn_action">[nsv_dict get btn_action nsperm passwd_resolve]</button>
+        |            </td>
+        |        </tr>
+        |    </table>
+        |</div>
         }]
         ]
-      ###
-    }
-    header {
-    ###
-    return [ns_trim -delimiter | [subst {
-    |<a href="http://127.0.0.1:8080/"><strong>NaviServer</strong></a>
-    |<span class="tagline">Programmable Web Server</span>
-    }]
-    ]
-    ###
-    }
-    meta {
-      return [ns_trim -delimiter | [subst {
-      |  <meta charset="utf-8" name="viewport" content="width=device-width, initial-scale=1.0">
-      |   <title>NaviServer – Welcome</title>
-      |   <link rel="stylesheet" href="doc/naviserver/man-5.0.css" type="text/css">
-      |   <link rel="icon" type="image/svg+xml" href="favicon.svg">
-      }]
-      ]
-    }
-      } ;# end switch
-    } ;# end try
+        ###
+      }
+      header {
+        ###
+        return [ns_trim -delimiter | [subst {
+        |<a href="http://127.0.0.1:8080/"><strong>NaviServer</strong></a>
+        |<span class="tagline">Programmable Web Server</span>
+        }]
+        ]
+        ###
+      }
+      meta {
+        ###
+        return [ns_trim -delimiter | [subst {
+        |  <meta charset="utf-8" name="viewport" content="width=device-width, initial-scale=1.0">
+        |   <title>NaviServer – Welcome</title>
+        |   <link rel="stylesheet" href="doc/naviserver/man-5.0.css" type="text/css">
+        |   <link rel="icon" type="image/svg+xml" href="favicon.svg">
+        }]
+        ]
+        ###
+      }
+    } ;# end switch
+  } ;# end try
   } ;# end proc
-
 
 proc show_howto {opt} {
   switch $opt {
@@ -184,13 +234,9 @@ proc show_howto {opt} {
       return [probe_nsstats]
     }
   }
-  } ;# end proc
+} ;# end proc
 %>
-
-<!--
-;#  Let's render above
---!>
-
+<!--  Rendering the above below --!>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -222,7 +268,6 @@ proc show_howto {opt} {
       <li><%=[probe_driver_info address]%></li>
       <li><%=[probe_driver_info modules]%></li>
     </div>
-
       <%=[display security_advice]%>
       <%=[display password_unchanged]%>
   </div>

--- a/index.adp
+++ b/index.adp
@@ -49,12 +49,12 @@ try {
 
     ;# Lets begin this adventure with our first switch
     ;#  Switch: $opt       - What option did we decide to call
-    ;#    Case: address      - Execute the code within our address case       - Display the address from our driver information variable
-    ;#    Case: modules      - Execute the code within our modules case       - Display the loaded modules
-    ;#    Case: navi_version - Execute the code within our navi_version case  - Display NaviServer's version
-    ;#    Case: port         - Execute the code within our port case          - Display the bound ports that NaviServer sits upon
-    ;#    Case: protocol     - Execute the code within our address case       - Display the working protocol
-    ;#    Case: os           - Execute the code within our address case       - Display our Operating System
+    ;#    Case: address      - Execute the code within our address case                - Display the address from our driver information variable
+    ;#    Case: modules      - Execute the code within our modules case                - Display the loaded modules
+    ;#    Case: navi_version - Execute the code within our navi_version case           - Display NaviServer's version
+    ;#    Case: port         - Execute the code within our port case                   - Display the bound ports that NaviServer sits upon
+    ;#    Case: protocol     - Execute the code within our address case                - Display the working protocol
+    ;#    Case: os           - Execute the code within our operating system case       - Display our Operating System
 
     switch $opt {
       address { ;# We need to differate between "Address" and "Addresses" in case of when the Navi instance is bound to one or more IP

--- a/index.adp
+++ b/index.adp
@@ -33,6 +33,7 @@ try {
                                           ;# this list enables us later on to pick and choose which value we desire
                                           ;# Enable to see the results :)
 
+    ;##### Variables for callings
     ;# Hold our driver information in to a list
     variable nssock_driver_info [concat {*}[ns_driver info]]
 
@@ -46,6 +47,7 @@ try {
     ;# Operating System & Version
     variable operating_system         $::tcl_platform(os)
     variable operating_system_version $::tcl_platform(osVersion)
+    ;#####
 
     ;# Lets begin this adventure with our first switch
     ;#  Switch: $opt       - What option did we decide to call
@@ -111,9 +113,12 @@ try {
 } ;# end try
 
 proc probe_nsstats {} {
+  ;#   Case: 0 - nsstats is not installed
+  nsv_dict set nsstats text not_installed {Module nsstats was not detected <a href="extras/?package=nsstats" class="btn-action">Install It Now</a>}
+  ;#   Case: 1 - nsstats is installed
+  nsv_dict set nsstats text installed {Explore the <a href="/nsstats.tcl"> the Navi Statistics Module</a> for real-time performance insights and logging analysis }
+
   try {
-    nsv_dict set nsstats text not_installed {Module nsstats was not detected <a href="extras/?package=nsstats" class="btn-action">Install It Now</a>}
-    nsv_dict set nsstats text installed {Explore the <a href="/nsstats.tcl"> the Navi Statistics Module</a> for real-time performance insights and logging analysis }
     ;# Check to see if our file exists
     variable ns_stats_existence [file exists [ns_server pagedir]/nsstats.tcl]
 
@@ -128,12 +133,14 @@ proc probe_nsstats {} {
 } ;# end proc
 
 proc display { args } {
-  try {
-    nsv_dict set image icon alert { &#9888; }
-    nsv_dict set btn_action nsperm passwd_msg {The default system administrator password remains unchanged}
-    nsv_dict set btn_action nsperm passwd_resolve {Change System Password Now}
-    nsv_dict set security secure page {Please replace or secure this default page to protect your server credentials.}
+  ;# Case: security_advice   - Displays a Security Notice with icon
+  nsv_dict set security secure page {Please replace or secure this default page to protect your server credentials.}
+  nsv_dict set image icon alert { &#9888; }
+  ;# Case: password_unchanged - Change your password!
+  nsv_dict set btn_action nsperm passwd_msg {The default system administrator password remains unchanged}
+  nsv_dict set btn_action nsperm passwd_resolve {Change System Password Now}
 
+  try {
     variable display_mode [lindex $args 0] ;# Display mode passed to the procedure
     switch $display_mode {
         css {
@@ -221,13 +228,16 @@ proc display { args } {
   } ;# end proc
 
 proc show_howto {opt} {
+  ;# Case: documentation
+  nsv_dict set show_howto documentation general "Review the <a href=\"doc/toc.html\">documentation</a> to understand complete setup instructions and feature details"
+  ;# Case: replace
+  nsv_dict set show_howto documentation replace_placeholder "Replace this placeholder page with your custom content by configuring the appropriate directory"
+
   switch $opt {
     documentation {
-      nsv_dict set show_howto documentation general "Review the <a href=\"doc/toc.html\">documentation</a> to understand complete setup instructions and feature details"
       return [nsv_dict get show_howto documentation general]
     }
     replace {
-      nsv_dict set show_howto documentation replace_placeholder "Replace this placeholder page with your custom content by configuring the appropriate directory"
       return [nsv_dict get show_howto documentation replace_placeholder]
     }
     nsstats {

--- a/index.adp
+++ b/index.adp
@@ -86,7 +86,7 @@ proc display { args } {
 
     variable display_mode [lindex $args 0] ;# Display mode passed to the procedure
     switch $display_mode {
-        css { return [read [open "/css/default.css" r]] }
+        css { return [read [open "/forest/fox/~navi/pages/css/default.css" r]] }
         welcome {
         ###
         return [ns_trim -delimiter | {
@@ -163,18 +163,10 @@ proc display { args } {
       }]
       ]
     }
-      connection_info_address { return [probe_driver_info address] }
-      connection_info_port    { return [probe_driver_info port] }
-      enabled_modules         { return [probe_driver_info modules] }
-      os_version              { return [probe_driver_info os] }
-      navi_version            { return [probe_driver_info navi_version] }
       } ;# end switch
     } ;# end try
   } ;# end proc
 
-proc local_port {port} {
-  variable port [probe_driver_info port]
-}
 
 proc show_howto {opt} {
   switch $opt {
@@ -223,10 +215,10 @@ proc show_howto {opt} {
 
     <h2>Current Server Configuration</h2>
     <div class="code">
-      <li><%=[display os_version]%></li>
-      <li><%=[display navi_version]%></li>
-      <li><%=[display connection_info_address]%></li>
-      <li><%=[display enabled_modules]%></li>
+      <li><%=[probe_driver_info os]%></li>
+      <li><%=[probe_driver_info navi_version]%></li>
+      <li><%=[probe_driver_info address]%></li>
+      <li><%=[probe_driver_info modules]%></li>
     </div>
 
       <%=[display security_advice]%>

--- a/index.adp
+++ b/index.adp
@@ -77,7 +77,7 @@ try {
         } ;# end switch llength
       }
 
-      modules {    ;# Show me the shades, return our modules
+      modules { ;# Show me the shades, return our modules
         variable modules [ns_ictl getmodules]
         variable modules [append modules "[nsv_dict get system modules_enabled live]"]
         #
@@ -90,7 +90,7 @@ try {
           "<code id=\"terminal\">NaviServer Version:</code> <code id=\"general\">$navi_version</code>"
       }
 
-      port {        ;# What ports are we bound on?
+      port { ;# What ports are we bound on?
         switch [llength [dict get $nssock_driver_info port]] {
           1       { return "<code id=\"terminal\">Listening at port: <code id=\"general\">$at_port</code>" }
           default { return "<code id=\"terminal\">Listening at ports: <code id=\"general\">$at_port</code>" }

--- a/index.adp
+++ b/index.adp
@@ -49,12 +49,12 @@ try {
 
     ;# Lets begin this adventure with our first switch
     ;#  Switch: $opt       - What option did we decide to call
-    ;#    Case: address      - Execute the code within our address case                - Display the address from our driver information variable
-    ;#    Case: modules      - Execute the code within our modules case                - Display the loaded modules
-    ;#    Case: navi_version - Execute the code within our navi_version case           - Display NaviServer's version
-    ;#    Case: port         - Execute the code within our port case                   - Display the bound ports that NaviServer sits upon
-    ;#    Case: protocol     - Execute the code within our address case                - Display the working protocol
-    ;#    Case: os           - Execute the code within our operating system case       - Display our Operating System
+    ;#    Case: address      - Execute the code within our address case       - Displays the address(es) from our driver information variable
+    ;#    Case: modules      - Execute the code within our modules case       - Displays the loaded modules
+    ;#    Case: navi_version - Execute the code within our navi_version case  - Displays NaviServer's version
+    ;#    Case: port         - Execute the code within our port case          - Displays the bound ports that NaviServer sits upon
+    ;#    Case: protocol     - Execute the code within our protocol case      - Displays the working protocol
+    ;#    Case: os           - Execute the code within our os case            - Displays our Operating System
 
     switch $opt {
       address { ;# We need to differate between "Address" and "Addresses" in case of when the Navi instance is bound to one or more IP
@@ -77,7 +77,7 @@ try {
         } ;# end switch llength
       }
 
-      modules { ;# Show me the shades, return our modules
+      modules {    ;# Show me the shades, return our modules
         variable modules [ns_ictl getmodules]
         variable modules [append modules "[nsv_dict get system modules_enabled live]"]
         #
@@ -90,7 +90,7 @@ try {
           "<code id=\"terminal\">NaviServer Version:</code> <code id=\"general\">$navi_version</code>"
       }
 
-      port { ;# What ports are we bound on?
+      port {        ;# What ports are we bound on?
         switch [llength [dict get $nssock_driver_info port]] {
           1       { return "<code id=\"terminal\">Listening at port: <code id=\"general\">$at_port</code>" }
           default { return "<code id=\"terminal\">Listening at ports: <code id=\"general\">$at_port</code>" }

--- a/index.adp
+++ b/index.adp
@@ -198,9 +198,7 @@ try {
                 |  Security Alert:</strong>
                 |  The 'nsperm' module is installed, but the default
                 |  system administrator password for 'nsadmin' remains
-                |  unchanged. Please update the password immediately.
-                |
-                |  <a href="#" id="changePwdBtn" class="btn-action">Change Password Now</a>
+                |  unchanged. <a href="#" id="changePwdBtn" class="btn-action">Change Password Now</a>
                 |
                 |  <div id="passwordModal" class="modal">
                 |    <div class="modal-content">

--- a/index.adp
+++ b/index.adp
@@ -28,7 +28,7 @@ try { proc probe_driver_info {opt} {
           }
           address { ;# Or maybe it was a address request
             ;#  This switch determines if the server is hosted on two IP addresses
-            ;#    A cute script to
+            ;#    cute
             switch [llength [dict get $nssock_driver_info address]] {
               1       { return "<code id=\"terminal\">Listening on address:[dict get $nssock_driver_info address]</code>\
                                 at port <code class=\"terminal\"> [dict get $nssock_driver_info port]</code>"  }

--- a/index.adp
+++ b/index.adp
@@ -80,13 +80,16 @@ proc probe_nsstats {} {
 
 proc display { args } {
   try {
+
+    # Dictonaries entries for displaying alerts
     nsv_dict set image icon alert { &#9888; }
     nsv_dict set btn_action nsperm passwd_msg {The default system administrator password remains unchanged}
     nsv_dict set btn_action nsperm passwd_resolve {Change System Password Now}
+    nsv_dict set security secure page {Please replace or secure this default page to protect your server credentials.}
 
     variable display_mode [lindex $args 0] ;# Display mode passed to the procedure
     switch $display_mode {
-        css { return [read [open "/forest/fox/~navi/pages/css/default.css" r]] }
+        css { return [read [open "[ns_server pagedir]/default.css" r]] }
         welcome {
         ###
         return [ns_trim -delimiter | {
@@ -102,7 +105,6 @@ proc display { args } {
         ###
       }
       security_advice {
-        nsv_dict set security secure page {Please replace or secure this default page to protect your server credentials.}
         ###
         return [ns_trim -delimiter | [subst {
         |<div class="security">
@@ -186,7 +188,7 @@ proc show_howto {opt} {
 %>
 
 <!--
-;#  This is the part where we cast the magic
+;#  Let's render above
 --!>
 
 <!DOCTYPE html>

--- a/nsperm/init.tcl
+++ b/nsperm/init.tcl
@@ -272,7 +272,7 @@ try {
         "Please, change the password using:  ns_permpasswd nsadmin x /NEWPASSWORD/\n" \
         "or edit the password file [file join [ns_info home] modules nsperm passwd]\n" \
         "and change the encrypted password manually!\n" \
-        "=============================================================================\n"
+        "============================================================================="
 } on error {errorMsg} {
 }
 

--- a/nsperm/init.tcl
+++ b/nsperm/init.tcl
@@ -266,13 +266,13 @@ try {
     ns_perm checkpass nsadmin x
 
 } on ok {result} {
-    ns_log security Administration action required!\n \
+    ns_log security Administration action required!\n\n \
         "=============================================================================\n" \
         "The default password for system administrator 'nsadmin' has not been changed!\n" \
         "Please, change the password using:  ns_permpasswd nsadmin x /NEWPASSWORD/\n" \
         "or edit the password file [file join [ns_info home] modules nsperm passwd]\n" \
         "and change the encrypted password manually!\n" \
-        "============================================================================="
+        "=============================================================================\n"
 } on error {errorMsg} {
 }
 


### PR DESCRIPTION
Before on startup if the default admin password hadn't been changed you'd receive a warning to do so.
A cosmetic bug where in console, it adds an empty new line after the last line of equal signs

Example below demonstrating the additional empty line before system debug
```
:     and change the encrypted password manually!
:     =============================================================================
:    
[25/Jul/2025:22:40:37][7329.33a660a92010][-main:default-] Notice: privatelib /forest/~navi/modules/tcl/revproxy is not a readable directory (ignored)
```

Removing the last \n would resolve the issue.