### PR TITLE
quic: fix SIGABRT under load, runaway event loop, and pollset leak

### DIFF
--- a/quic/quic.c
+++ b/quic/quic.c
@@ -7269,7 +7269,7 @@ QuicThread(void *arg)
     unsigned int        flags = NS_DRIVER_THREAD_STARTED;
     struct timeval     *polltimeout_ptr;
 
-    Ns_ThreadSetName("-quic:%s-", "h3");
+    Ns_ThreadSetName("-driver:quic:%s-", "h3");
     Ns_Log(Notice, "H3D QUIC THREAD started");
 
     nrBindaddrs = NsDriverBindAddresses(drvPtr);
@@ -7280,10 +7280,8 @@ QuicThread(void *arg)
     } else {
         flags |= (NS_DRIVER_THREAD_FAILED | NS_DRIVER_THREAD_SHUTDOWN);
     }
-    fprintf(stderr, "DEBUG: QUIC lock driver %p\n", (void*)drvPtr->lock);
     Ns_MutexLock(&drvPtr->lock);
     drvPtr->flags |= flags;
-    fprintf(stderr, "DEBUG: QUIC BROADCAST flags %.2x\n", flags);
     Ns_CondBroadcast(&drvPtr->cond);
     Ns_MutexUnlock(&drvPtr->lock);
 

--- a/quic/quic.c
+++ b/quic/quic.c
@@ -2093,8 +2093,17 @@ static void quic_conn_handle_ic(SSL *listener_ssl, Driver *drvPtr) {
                                                 0 /* application error code on reject */));
 
         /* 4) Finally, add it into active-connection list so Recv/Send see it */
+        /*
+         * Do not register OSB/OSU here. Per SSL_poll(3) these are stream-creation
+         * flow control READINESS flags -- they are raised whenever flow control
+         * permits creating another stream, i.e. almost always -- so SSL_poll()
+         * returns immediately on every iteration and the driver spins.
+         * OpenSSL's own reference server registers only ISB|ISU on a connection
+         * (demos/quic/poll-server/quic-server-ssl-poll-http.c) and notes that
+         * OSB/OSU "must be monitored once there is a request for outbound stream
+         * created by app". EC/ECD/ER/EW are added by PollsetDefaultConnErrors().
+         */
         PollsetAddConnection(dc, conn,
-                             SSL_POLL_EVENT_OSB | SSL_POLL_EVENT_OSU |
                              SSL_POLL_EVENT_ISB | SSL_POLL_EVENT_ISU);
 
         Ns_Log(Notice, "[%lld] H3 accept_connection cc->h3ssl.conn %p ex_data %p",

--- a/quic/quic.c
+++ b/quic/quic.c
@@ -237,6 +237,7 @@ typedef struct ConnCtx {
     bool            wants_write;
     bool            expecting_send;     // set when request dispatched to app
     bool            conn_closed;
+    Ns_Time         last_activity;  /* for reclaiming peers that vanished without CONNECTION_CLOSE */
     int             last_sd; // intermediate, for debuggung in ossl_conn_maybe_log_first_shutdown
     SharedState     shared;  // stable pointer
 
@@ -499,6 +500,13 @@ static inline void     PollsetUpdateConnPollInterest(ConnCtx *cc) NS_GNUC_NONNUL
 static size_t          PollsetHandleListenerEvents(NsTLSConfig *dc) NS_GNUC_NONNULL(1);
 static void            PollsetMarkDead(ConnCtx *cc, SSL *conn, const char *msg) NS_GNUC_NONNULL(1,2);
 static void            PollsetSweep(NsTLSConfig *dc) NS_GNUC_NONNULL(1);
+
+/*
+ * How long a QUIC connection may sit with no poll activity before we tear it down.
+ * Guards against peers that disappear without a clean shutdown, which would otherwise
+ * keep their streams in the pollset forever. 0 disables reclamation.
+ */
+static Ns_Time h3ConnIdleTimeout = { 60, 0 };
 static void            PollsetConsolidate(NsTLSConfig *dc) NS_GNUC_NONNULL(1);
 
 
@@ -2094,14 +2102,15 @@ static void quic_conn_handle_ic(SSL *listener_ssl, Driver *drvPtr) {
 
         /* 4) Finally, add it into active-connection list so Recv/Send see it */
         /*
-         * Do not register OSB/OSU here. Per SSL_poll(3) these are stream-creation
-         * flow control READINESS flags -- they are raised whenever flow control
-         * permits creating another stream, i.e. almost always -- so SSL_poll()
-         * returns immediately on every iteration and the driver spins.
-         * OpenSSL's own reference server registers only ISB|ISU on a connection
-         * (demos/quic/poll-server/quic-server-ssl-poll-http.c) and notes that
-         * OSB/OSU "must be monitored once there is a request for outbound stream
-         * created by app". EC/ECD/ER/EW are added by PollsetDefaultConnErrors().
+         * Do NOT register OSB/OSU here. Per SSL_poll(3) these are flow-control
+         * READINESS flags -- "stream creation flow control currently permits at
+         * least one additional stream to be created" -- so they are set almost
+         * always, SSL_poll() returns immediately every iteration, and the driver
+         * spins at 100% CPU. OpenSSL's own reference server
+         * (demos/quic/poll-server/quic-server-ssl-poll-http.c) registers only
+         * ISB|ISU here and notes: "SSL_POLL_EVENT_OSB (or SSL_POLL_EVENT_OSU)
+         * must be monitored once there is a request for outbound stream created
+         * by app." EC/ECD/ER/EW are added by PollsetDefaultConnErrors().
          */
         PollsetAddConnection(dc, conn,
                              SSL_POLL_EVENT_ISB | SSL_POLL_EVENT_ISU);
@@ -5397,6 +5406,7 @@ ConnCtxNew(NsTLSConfig *dc, SSL *conn)
     cc->h3ssl.conn = conn;
     cc->h3ssl.bidi_sid = (uint64_t)-1;
     cc->pidx = (size_t)-1;
+    Ns_GetTime(&cc->last_activity);
 
     return cc;
 }
@@ -6691,6 +6701,16 @@ PollsetSweep(NsTLSConfig *dc)
     enum { MAX_SWEEP_FREES = 256 };
     SSL   *to_free[MAX_SWEEP_FREES];
     size_t i, nfree = 0;
+    /*
+     * Connections whose peer went away without a clean shutdown. Collected here and
+     * torn down after the loop: quic_conn_enter_shutdown() mutates the pollset we are
+     * iterating, so it must not be called from inside this loop.
+     */
+    ConnCtx *to_reap[MAX_SWEEP_FREES];
+    size_t   nreap = 0;
+    Ns_Time  sweepNow;
+
+    Ns_GetTime(&sweepNow);
 
     Ns_Log(Notice, "[%lld] PollsetSweep begin npoll %ld", (long long)dc->iter, PollsetCount(dc));
     for (i = 0; i < PollsetCount(dc); i++) {
@@ -6716,6 +6736,42 @@ PollsetSweep(NsTLSConfig *dc)
 
         /* 1) Connection object? Treat it as conn regardless of stream_type. */
         if (s == cc->h3ssl.conn) {
+            /*
+             * Peer vanished without CONNECTION_CLOSE? Then can_be_freed_postloop()
+             * will never return true (SSL_RECEIVED_SHUTDOWN never arrives) and this
+             * connection would stay in the pollset for the life of the process.
+             * Reclaim it once it has been silent for connidletimeout, unless it still
+             * has requests in flight (a slow download must not be killed).
+             */
+            if ((h3ConnIdleTimeout.sec != 0 || h3ConnIdleTimeout.usec != 0)
+                && cc->handshake_done) {
+                Ns_Time idle, hard;
+                bool    expired;
+
+                /* Elapsed since the peer last did anything (positive interval). */
+                (void)Ns_DiffTime(&sweepNow, &cc->last_activity, &idle);
+
+                /*
+                 * Hard deadline: a connection with no peer activity for this long is
+                 * stuck, not slow, so reclaim it even though it still reports a live
+                 * request. Without this, a wedged request pins the connection -- and
+                 * its streams -- in the pollset forever.
+                 */
+                hard = h3ConnIdleTimeout;
+                hard.sec *= 5;
+
+                expired = (Ns_DiffTime(&idle, &hard, NULL) > 0)
+                    || (Ns_DiffTime(&idle, &h3ConnIdleTimeout, NULL) > 0
+                        && !quic_conn_has_live_requests(cc));
+
+                if (expired && nreap < MAX_SWEEP_FREES) {
+                    Ns_Log(Notice, "[%lld] H3 PollsetSweep: reaping idle conn %p "
+                           "(no peer activity for %ld.%06ld s, peer never sent CONNECTION_CLOSE)",
+                           (long long)dc->iter, (void*)s, (long)idle.sec, (long)idle.usec);
+                    to_reap[nreap++] = cc;
+                    continue;
+                }
+            }
             if (quic_conn_can_be_freed_postloop(s, cc)) {
                 Ns_Log(Notice, "[%lld] H3 PollsetSweep: kill conn %p", (long long)dc->iter, (void*)s);
                 PollsetMarkDead(cc, s, "conn postloop free");
@@ -6824,6 +6880,17 @@ PollsetSweep(NsTLSConfig *dc)
     for (size_t k = 0; k < nfree; k++) {
         Ns_Log(Notice, "[%lld] PollsetSweep calls SSL_free %p", (long long)dc->iter, (void*)to_free[k]);
         SSL_free(to_free[k]);
+    }
+
+    /*
+     * Reap connections whose peer vanished. This MUST come after the to_free[] pass
+     * above: quic_conn_enter_shutdown() frees every stream of the connection, and a
+     * stream could also be sitting in to_free[] -- freeing in the other order double
+     * frees it (observed as SIGBUS/SIGSEGV/SIGABRT under load). Slots freed above are
+     * already NULL in the pollset, so enter_shutdown() skips them.
+     */
+    for (size_t k = 0; k < nreap; k++) {
+        quic_conn_enter_shutdown(to_reap[k], "idle timeout, peer gone");
     }
     Ns_Log(Notice, "[%lld] PollsetSweep DONE", (long long)dc->iter);
 }
@@ -7129,6 +7196,13 @@ NS_EXPORT Ns_ReturnCode Ns_ModuleInit(const char *server, const char *module)
                            "10ms", 0, 0, LONG_MAX, 0,
                            &timeout);
     NsTimeToTimeval(&timeout, &dc->u.h3.drain_timeout);
+    /*
+     * Reclaim connections whose peer vanished without CONNECTION_CLOSE; without this
+     * their streams stay in the pollset forever and the driver spins over dead entries.
+     */
+    Ns_ConfigTimeUnitRange(section, "connidletimeout",
+                           "60s", 0, 0, LONG_MAX, 0,
+                           &h3ConnIdleTimeout);
 
     Ns_MutexInit(&dc->u.h3.waker_lock);
 
@@ -7455,6 +7529,22 @@ QuicThread(void *arg)
               Tcl_DStringFree(&ds);*/
 
             processed_event = 0;
+
+            /*
+             * Any event on this connection (or one of its streams) means the peer is
+             * still there; refresh the connection's idle deadline.
+             */
+            if (cc != NULL
+                && (revents & ~(uint64_t)(SSL_POLL_EVENT_OSB
+                                          | SSL_POLL_EVENT_OSU
+                                          | SSL_POLL_EVENT_W)) != 0) {
+                /*
+                 * Only peer-driven events count as activity. OSB/OSU/W are
+                 * outgoing-capacity flags that stay set even when the peer is gone,
+                 * so counting them would keep a dead connection alive forever.
+                 */
+                Ns_GetTime(&cc->last_activity);
+            }
 
             {
                 Tcl_DStringInit(&ds);


### PR DESCRIPTION
Running the QUIC/h3 driver on a live site turned up three problems. Each is reproducible, and each commit stands alone.

**Environment:** NaviServer main, Tcl 9.1b0, **OpenSSL 4.0.1** (9 Jun 2026), Ubuntu, 2 cores. Symptoms before these fixes: `systemd-journald` burning ~76% of one core, **30 GB of log in 12 minutes**, nsd core-dumping **13 times in 10 days**, and h3 eventually refusing all connections while HTTP/2 stayed perfectly healthy.

---

### 1. Driver thread name → SIGABRT under load

`CreateConnThread()` (`nsd/queue.c`) asserts the calling thread is `-driver:`/`-main`/`-spooler`/`-service-`. `QuicThread()` named itself `-quic:h3-`, so **every time h3 traffic forced the conn pool to grow, nsd aborted**:

```
nsd: queue.c:3103: CreateConnThread: Assertion
`strncmp("-driver:", threadName, 8u) == 0 || ...' failed.
```

Core's own driver threads use `-driver:%s-` (`nsd/driver.c:2920`). Renamed to `-driver:quic:h3-`, keeping `quic` so log lines stay identifiable. Zero aborts since. Also removes two unconditional `fprintf(stderr)` debug lines that bypass `Ns_Log` and so can't be filtered by severity.

### 2. Permanent OSB/OSU poll interest → the runaway event loop

This is the main one.

`accept_connection()` registered `OSB | OSU | ISB | ISU`. Per `SSL_poll(3)`, OSB/OSU are raised when *"stream creation flow control currently permits at least one additional stream to be locally created"* — a **level-triggered readiness condition that is set essentially always**. `SSL_poll()` therefore returns immediately every iteration and the driver never blocks. In the traces, connection items permanently showed `revents 1800 OSB|OSU` while every stream item showed `revents 0000 NONE`.

OpenSSL's own reference server registers only `ISB|ISU` on a connection (`demos/quic/poll-server/quic-server-ssl-poll-http.c`) and documents the rule:

> `SSL_POLL_EVENT_OSB` (or `SSL_POLL_EVENT_OSU`) must be monitored once there is a request for outbound stream created by app

i.e. added on demand for an outgoing stream, then cleared.

| | before | after |
|---|---|---|
| h3 thread CPU (idle, post-load) | 100% | **0%** |
| log volume per stress run | 30 GB | **13 MB** |
| stress at concurrency 3 | wedged immediately | **all scenarios pass** |

Close detection is unaffected — `EC/ECD/ER/EW` are still registered via `PollsetDefaultConnErrors()`.

### 3. Pollset leaks connections whose peer vanished

`quic_conn_can_be_freed_postloop()` frees only after a **clean bilateral** shutdown (both `SSL_SENT_SHUTDOWN` *and* `SSL_RECEIVED_SHUTDOWN`). A peer that simply disappears — process killed, NAT/idle drop, tab closed mid-download — never sends CONNECTION_CLOSE, so the connection is never freed and its CTRL/QPACK and the peer's uni streams stay in the pollset for the life of the process. Measured: **npoll stuck at 191 with zero clients connected.**

`idletimeout` doesn't help: it's only ever the `SSL_poll()` timeout, never a per-connection deadline, and `ConnCtx` had no last-activity record.

Adds `ConnCtx.last_activity`, a `connidletimeout` parameter (default 60s, 0 disables), and reclamation in `PollsetSweep()` via the existing `quic_conn_enter_shutdown()`. Three load-bearing details, each learned the hard way:

- Reclamation is deferred until **after** the `SSL_free(to_free[])` pass — `enter_shutdown()` frees the connection's streams and a stream may also be in `to_free[]`; the other order double frees (SIGBUS/SEGV/SIGABRT under load).
- Only **peer-driven** events refresh `last_activity`. OSB/OSU/W stay set when the peer is long gone, so counting them lets a dead connection keep itself alive forever.
- A hard deadline (5×) reclaims even when the connection still reports a live request — no peer activity for minutes means stuck, not slow.

**I'm not attached to this particular mechanism.** If you'd rather reclaim at a different point, commits 1 and 2 stand on their own.

---

### Still broken — not addressed here

I'd rather be upfront about what these patches don't fix:

- **h3 still wedges at higher concurrency.** At concurrency 6 the first scenario passes, then everything after returns connection errors, while the HTTPS canary stays 200 and nsd never crashes.
- **Orphaned stream entries still accumulate.** Per sweep: ~1 connection item but ~32 CTRL / ~32 QPACK-encoder / ~32 QPACK-decoder / ~92 client-uni belonging to connections that are already gone. Routing the `can_be_freed_postloop` branch through `quic_conn_enter_shutdown()` looked like the obvious fix but **reintroduced the spin**, so I left it out rather than guess.
- Frequent `Error: return: failed to redirect '404': exceeded recursion limit of 3` — separate and uninvestigated.

**We're continuing to work on these** and will follow up with what we find. The next experiment is building OpenSSL master (there are ~6 weeks of fixes past the 4.0.1 cut) and re-running the stress suite, to establish whether the residual concurrency wedge is ours or upstream's — [openssl/openssl#24166](https://github.com/openssl/openssl/issues/24166) ("QUIC: Blocking calls are unreliable in multi-threaded usage") is still open and affects master.

### Testing

Python + aioquic stress harness with scenarios for small/large/range/multiplex/abort/churn/idle. It watches the server as well as the client — tracking the nsd pid (so a crash-and-restart is detected rather than read as a slow response) and polling a plain HTTPS canary to distinguish "h3 wedged" from "server down". Happy to contribute it under `tests/` if that's useful.

One note in case it saves you time: on this box `openssl version` reports 3.5.5 (the distro CLI), but nsd links 4.0.1 from a separate prefix. The process also has `libssl.so.3` resident via `libmysqlclient` → mysqltcl; that's version-isolated (`OPENSSL_3.0.0` vs `OPENSSL_4.0.0` symbol versions) and nowhere near the QUIC path.
