### PR TITLE
quic: free a connection's streams with it (pollset leak)

### DIFF
--- a/quic/quic.c
+++ b/quic/quic.c
@@ -499,6 +499,11 @@ static inline void     PollsetUpdateConnPollInterest(ConnCtx *cc) NS_GNUC_NONNUL
 static size_t          PollsetHandleListenerEvents(NsTLSConfig *dc) NS_GNUC_NONNULL(1);
 static void            PollsetMarkDead(ConnCtx *cc, SSL *conn, const char *msg) NS_GNUC_NONNULL(1,2);
 static void            PollsetSweep(NsTLSConfig *dc) NS_GNUC_NONNULL(1);
+static size_t          PollsetReapConnStreams(NsTLSConfig *dc, ConnCtx *cc, SSL **to_free,
+                                              size_t nfree, size_t maxfree) NS_GNUC_NONNULL(1,2,3);
+
+/* Upper bound on SSL objects collected in one teardown/sweep pass. */
+#define H3_MAX_REAP 256
 static void            PollsetConsolidate(NsTLSConfig *dc) NS_GNUC_NONNULL(1);
 
 
@@ -1217,35 +1222,30 @@ quic_conn_enter_shutdown(ConnCtx *cc, const char *why)
 
     /* Try to emit CONNECTION_CLOSE; harmless if already closing */
     (void)SSL_shutdown(conn);
+    /*
+     * Once only. This previously called SSL_handle_events() a second time as an
+     * argument to Ns_Log() - a side effect inside a log statement, evaluated even
+     * when the severity is disabled.
+     */
     (void)SSL_handle_events(conn);
-    Ns_Log(Notice, "[%lld] SSL_handle_events in quic_conn_enter_shutdown conn %p => %d",
-           (long long)dc->iter, (void*)conn, SSL_handle_events(conn));
+    Ns_Log(Notice, "[%lld] SSL_handle_events in quic_conn_enter_shutdown conn %p",
+           (long long)dc->iter, (void*)conn);
 
-    /* Remove all stream items owned by this connection */
-    for (size_t i = 0; i < PollsetCount(dc); ++i) {
-        ConnCtx *owner;
-        SSL     *s = (SSL *)dc->u.h3.ssl_items.data[i];
+    /*
+     * Remove all stream items owned by this connection.
+     *
+     * This used to select streams with SSL_get_ex_data(s, cc_idx) == cc, which
+     * never matches - streams do not carry cc_idx (see PollsetAddStreamRegister),
+     * so the connection was torn down while its CTRL/QPACK streams and the peer's
+     * uni streams stayed in the pollset for the life of the process.
+     */
+    {
+        SSL   *reaped[H3_MAX_REAP];
+        size_t nreaped, k;
 
-        if (s == NULL) {
-            continue;
-        }
-
-        owner = SSL_get_ex_data(s, dc->u.h3.cc_idx);
-        if (owner != cc) {
-            continue;
-        }
-
-        if (s != conn) {
-            StreamCtx *sc = SSL_get_ex_data(s, dc->u.h3.sc_idx);
-
-            if (sc) {
-                /* Drop interest; unregister mapping; free */
-                PollsetDisableRead(dc, s, sc, "quic_conn_enter_shutdown");
-                PollsetDisableWrite(dc, s, sc, "quic_conn_enter_shutdown");
-                StreamCtxUnregister(sc);
-            }
-            PollsetMarkDead(cc, s, "conn shutdown");
-            SSL_free(s);
+        nreaped = PollsetReapConnStreams(dc, cc, reaped, 0u, (size_t)H3_MAX_REAP);
+        for (k = 0; k < nreaped; k++) {
+            SSL_free(reaped[k]);
         }
     }
 
@@ -6675,6 +6675,72 @@ PollsetMarkDead(ConnCtx *cc, SSL *ssl, const char *msg)
  *
  *----------------------------------------------------------------------
  */
+/*
+ *----------------------------------------------------------------------
+ *
+ * PollsetReapConnStreams --
+ *
+ *      Remove every pollset entry belonging to a connection, except the
+ *      connection entry itself: drop interest, unregister the stream context,
+ *      mark the slot dead, and hand the SSL object to the caller's deferred
+ *      free list.
+ *
+ *      The owner is resolved through the StreamCtx back-pointer, NOT through
+ *      cc_idx: streams never carry cc_idx, because the SSL_set_ex_data() that
+ *      would set it is commented out in PollsetAddStreamRegister(). Matching on
+ *      cc_idx alone therefore finds nothing, which is what leaked the streams.
+ *      This mirrors how the dispatch loop already resolves ownership.
+ *
+ *      Bookkeeping only - deliberately no SSL_shutdown()/SSL_handle_events(),
+ *      so this can be used on an already-closed connection without re-entering
+ *      the QUIC reactor.
+ *
+ * Results:
+ *      New count of entries in to_free.
+ *
+ * Side effects:
+ *      Marks pollset slots dead. Frees nothing itself.
+ *
+ *----------------------------------------------------------------------
+ */
+static size_t
+PollsetReapConnStreams(NsTLSConfig *dc, ConnCtx *cc, SSL **to_free,
+                       size_t nfree, size_t maxfree)
+{
+    size_t i;
+
+    NS_NONNULL_ASSERT(dc != NULL);
+    NS_NONNULL_ASSERT(cc != NULL);
+    NS_NONNULL_ASSERT(to_free != NULL);
+
+    for (i = 0; i < PollsetCount(dc); i++) {
+        SSL       *s = (SSL *)dc->u.h3.ssl_items.data[i];
+        ConnCtx   *owner;
+        StreamCtx *sc;
+
+        if (s == NULL || s == cc->h3ssl.conn) {
+            continue;
+        }
+
+        sc    = SSL_get_ex_data(s, dc->u.h3.sc_idx);
+        owner = (sc != NULL) ? sc->cc : SSL_get_ex_data(s, dc->u.h3.cc_idx);
+        if (owner != cc) {
+            continue;
+        }
+
+        if (sc != NULL) {
+            PollsetDisableRead(dc, s, sc, "PollsetReapConnStreams");
+            PollsetDisableWrite(dc, s, sc, "PollsetReapConnStreams");
+            StreamCtxUnregister(sc);
+        }
+        PollsetMarkDead(cc, s, "conn freed: reap stream");
+        if (nfree < maxfree) {
+            to_free[nfree++] = s;
+        }
+    }
+    return nfree;
+}
+
 static void
 PollsetSweep(NsTLSConfig *dc)
 {
@@ -6709,6 +6775,8 @@ PollsetSweep(NsTLSConfig *dc)
         if (s == cc->h3ssl.conn) {
             if (quic_conn_can_be_freed_postloop(s, cc)) {
                 Ns_Log(Notice, "[%lld] H3 PollsetSweep: kill conn %p", (long long)dc->iter, (void*)s);
+                /* Take the connection's streams with it, or they are orphaned. */
+                nfree = PollsetReapConnStreams(dc, cc, to_free, nfree, MAX_SWEEP_FREES);
                 PollsetMarkDead(cc, s, "conn postloop free");
                 if (nfree < MAX_SWEEP_FREES) {
                     to_free[nfree++] = s;


### PR DESCRIPTION
Separate topic from #22, and independent of it — this branch is cut from `main` and touches none of the same code (no thread naming, no poll-event masks, no idle reclamation). Either can go in first.

### The bug

Tearing down a QUIC connection leaves its CTRL, QPACK-encoder, QPACK-decoder and the peer's uni streams in the pollset **for the life of the process**.

`quic_conn_enter_shutdown()` selects streams to remove with:

```c
owner = SSL_get_ex_data(s, dc->u.h3.cc_idx);
if (owner != cc) continue;
```

But a stream SSL never carries `cc_idx` — the call that would set it is commented out in `PollsetAddStreamRegister()`:

```c
SSL_set_app_data(s, dc);
//SSL_set_ex_data(s, dc->u.h3.cc_idx, cc);
```

So the loop matches nothing. On a live server: **18 connection teardowns produced 18 `conn shutdown (self)` marks but only ~4 stream marks**, where ~108 were expected. The same `cc_idx` lookup at the top of `PollsetSweep()` then classifies those entries as foreign objects and `continue`s past them, so nothing else reclaims them either.

### The fix

The driver already resolves ownership correctly in the dispatch loop, via the `StreamCtx` back-pointer:

```c
sc = SSL_get_ex_data(s, dc->u.h3.sc_idx);
cc = (sc != NULL) ? sc->cc : SSL_get_ex_data(s, dc->u.h3.cc_idx);
```

`PollsetReapConnStreams()` uses that same two-step resolution, and is called from `quic_conn_enter_shutdown()` and from `PollsetSweep()`'s postloop-free branch.

It is deliberately **bookkeeping only** — no `SSL_shutdown()`, no `SSL_handle_events()` — so it is safe on an already-closed connection without re-entering the QUIC reactor. That matters: an earlier attempt of mine that routed this through `quic_conn_enter_shutdown()` wholesale drove a shutdown handshake on already-closed connections and put the driver back into a busy loop.

I chose this over simply un-commenting the `SSL_set_ex_data()` line: restoring `cc_idx` on streams would also change what `PollsetSweep()`'s top-level lookup returns for **every** stream entry, which is a much wider behavioural change than fixing the two lookups that are actually wrong. Happy to go the other way if you prefer — you'll know why that line is commented out.

### Measured

Same workload (concurrency 3, 2 rounds) and same log window:

| | before | after |
|---|---|---|
| CTRL / QPACK-enc / QPACK-dec | 251 / 251 / 251 | **30 / 30 / 30** |
| CLIENT_UNI | 701 | **84** |
| connection entries | 63 | **88** |
| npoll under load | 112 | **24** |
| **npoll at idle** | **191 with zero clients** | **1 — the listener** |
| streams reaped | 0 | **107** |

107 reclaimed across 18 teardowns is ~5.9 per connection, matching CTRL + QPACK×2 + the peer's uni streams. The pollset now drains completely.

### Also in here

`quic_conn_enter_shutdown()` called `SSL_handle_events()` twice — once directly, then again as an argument to `Ns_Log()`:

```c
(void)SSL_handle_events(conn);
Ns_Log(Debug, "... => %d", ..., SSL_handle_events(conn));
```

A side effect inside a log statement, evaluated even when the severity is off. Now called once. (Independently of the tidiness: `SSL_handle_events()` is the call that can block indefinitely inside `ossl_quic_reactor_tick()` — see the discussion in #22 — so halving the number of entries into it on the shutdown path is worth having.)

### Testing

Built against current `main` and verified in isolation (this branch only, none of #22 applied). Stress scenarios small / large / range / multiplex all pass; `npoll` returns to 1 at idle; 0% CPU idle; no crashes.
