### PR TITLE
quic: name the driver thread -driver:quic:h3- to stop SIGABRT under load

### DIFF
--- a/quic/quic.c
+++ b/quic/quic.c
@@ -7269,7 +7269,7 @@ QuicThread(void *arg)
     unsigned int        flags = NS_DRIVER_THREAD_STARTED;
     struct timeval     *polltimeout_ptr;
 
-    Ns_ThreadSetName("-quic:%s-", "h3");
+    Ns_ThreadSetName("-driver:quic:%s-", "h3");
     Ns_Log(Notice, "H3D QUIC THREAD started");
 
     nrBindaddrs = NsDriverBindAddresses(drvPtr);
@@ -7280,10 +7280,8 @@ QuicThread(void *arg)
     } else {
         flags |= (NS_DRIVER_THREAD_FAILED | NS_DRIVER_THREAD_SHUTDOWN);
     }
-    fprintf(stderr, "DEBUG: QUIC lock driver %p\n", (void*)drvPtr->lock);
     Ns_MutexLock(&drvPtr->lock);
     drvPtr->flags |= flags;
-    fprintf(stderr, "DEBUG: QUIC BROADCAST flags %.2x\n", flags);
     Ns_CondBroadcast(&drvPtr->cond);
     Ns_MutexUnlock(&drvPtr->lock);
 


### PR DESCRIPTION
One of three PRs split out of #22 (now closed) so each topic can be reviewed on its own. Independent of the others — cut from `main`, compile-tested with none of the others applied.

### The problem

`CreateConnThread()` (`nsd/queue.c`) asserts that the thread growing the connection pool is one of `-driver:` / `-main` / `-spooler` / `-service-`:

```
nsd: queue.c:3103: CreateConnThread: Assertion
`strncmp("-driver:", threadName, 8u) == 0 || ...' failed.
```

`QuicThread()` names itself `-quic:h3-`, so **every time h3 traffic forces the connection pool to grow, nsd aborts.** On a live site that was **13 core dumps in 10 days**. systemd restarts the service each time, so from the outside it looks healthy while clients see dropped connections.

### The fix

Core's own driver threads use `-driver:%s-` (`nsd/driver.c:2920`). `QuicThread` is a driver thread, so name it the same way, keeping `quic` in the name so its log lines stay identifiable:

```c
Ns_ThreadSetName("-driver:quic:%s-", "h3");
```

Zero aborts since.

Also removes two unconditional `fprintf(stderr, "DEBUG: QUIC …")` lines that bypass `Ns_Log()` and so cannot be filtered by severity.

If you'd rather widen the assertion in `queue.c` than rename the thread, that works too — I went with the rename because it makes the QUIC driver consistent with every other driver.
