### PR TITLE
quic: do not poll OSB/OSU permanently -- the runaway event loop

### DIFF
--- a/quic/quic.c
+++ b/quic/quic.c
@@ -2093,8 +2093,17 @@ static void quic_conn_handle_ic(SSL *listener_ssl, Driver *drvPtr) {
                                                 0 /* application error code on reject */));
 
         /* 4) Finally, add it into active-connection list so Recv/Send see it */
+        /*
+         * Do not register OSB/OSU here. Per SSL_poll(3) these are stream-creation
+         * flow control READINESS flags -- they are raised whenever flow control
+         * permits creating another stream, i.e. almost always -- so SSL_poll()
+         * returns immediately on every iteration and the driver spins.
+         * OpenSSL's own reference server registers only ISB|ISU on a connection
+         * (demos/quic/poll-server/quic-server-ssl-poll-http.c) and notes that
+         * OSB/OSU "must be monitored once there is a request for outbound stream
+         * created by app". EC/ECD/ER/EW are added by PollsetDefaultConnErrors().
+         */
         PollsetAddConnection(dc, conn,
-                             SSL_POLL_EVENT_OSB | SSL_POLL_EVENT_OSU |
                              SSL_POLL_EVENT_ISB | SSL_POLL_EVENT_ISU);
 
         Ns_Log(Notice, "[%lld] H3 accept_connection cc->h3ssl.conn %p ex_data %p",


### PR DESCRIPTION
One of three PRs split out of #22 (now closed) so each topic can be reviewed on its own. Independent of the others — cut from `main`, compile-tested with none of the others applied.

### The problem

`accept_connection()` registers the connection with

```c
PollsetAddConnection(dc, conn,
                     SSL_POLL_EVENT_OSB | SSL_POLL_EVENT_OSU |
                     SSL_POLL_EVENT_ISB | SSL_POLL_EVENT_ISU);
```

Per `SSL_poll(3)`, OSB/OSU are raised when *"stream creation flow control currently permits at least one additional [bi|uni]directional stream to be locally created"*. That is a **level-triggered readiness condition that is set essentially always**, so `SSL_poll()` returns immediately on every iteration and the driver never blocks.

Observed on a live server (NaviServer main, Tcl 9.1b0, OpenSSL 4.0.1): the h3 thread pinned one core at **100%** and wrote **~1250 trace lines/sec — 30 GB of log in 12 minutes**, and 99.97% of all system log volume. In the traces, connection poll items permanently showed `revents 1800 OSB|OSU` while every stream item showed `revents 0000 NONE`.

### The fix

OpenSSL's own reference server registers only `ISB|ISU` on a connection (`demos/quic/poll-server/quic-server-ssl-poll-http.c`) and documents the rule:

> `SSL_POLL_EVENT_OSB` (or `SSL_POLL_EVENT_OSU`) must be monitored once there is a request for outbound stream created by app

i.e. added on demand when the application wants to create an outgoing stream, then cleared.

| | before | after |
|---|---|---|
| h3 thread CPU (idle, after load) | 100% | **0%** |
| log volume per stress run | 30 GB | **13 MB** |
| stress at concurrency 3 | wedged immediately | **all scenarios pass** |

Connection close detection is unaffected — `EC/ECD/ER/EW` are still registered via `PollsetDefaultConnErrors()`.

Note this does **not** fix everything: h3 still wedges at higher concurrency, but that turned out to be an OpenSSL defect (`SSL_poll()` with a finite timeout parking forever in `ossl_quic_reactor_tick()`, reproducible on 4.0.1 and on master) rather than anything in this driver. Details and backtrace are in the discussion on #22.
