### PR TITLE
quic: handle SSL_R_STREAM_FINISHED in the h3 write path (stop a reason=365 Error-log flood) [WIP]

### DIFF
--- a/quic/quic.c
+++ b/quic/quic.c
@@ -2937,6 +2937,32 @@ h3_conn_write_step(ConnCtx *cc)
                                 return NS_TRUE; /* writer should be scheduled to complete shutdown */
                             }
 
+                            if (r == SSL_R_STREAM_FINISHED) {
+                                /*
+                                 * The write side of this stream is already
+                                 * concluded (we sent FIN); OpenSSL correctly
+                                 * refuses further writes with STREAM_FINISHED.
+                                 * Returning NS_TRUE here would reschedule the
+                                 * SAME doomed write and re-fail identically on
+                                 * every poll iteration -- a tight Error-log flood
+                                 * (an "SSL_write_ex2: reason=365" storm) that only
+                                 * stops when the connection is reclaimed.  Treat it
+                                 * as terminal for this stream's write half: stop
+                                 * nghttp3 producing more body, mark FIN done, drop
+                                 * write interest, and move to the next stream.
+                                 */
+                                Ns_Log(Notice, "[%lld] H3[%lld] write on already-finished"
+                                       " stream; dropping write interest",
+                                       (long long)dc->iter, (long long)sid);
+                                nghttp3_conn_shutdown_stream_write(cc->h3conn, sid);
+                                sc->io_state |= H3_IO_TX_FIN;
+                                ERR_clear_error();
+                                (void)SSL_handle_events(stream);
+                                PollsetDisableWrite(dc, stream, sc,
+                                       "h3_conn_write_step SSL_R_STREAM_FINISHED");
+                                goto next_sid;
+                            }
+
                             Ns_Log(Error, "[%lld] H3[%lld] SSL_write_ex2: reason=%d (%s)",
                                    (long long)dc->iter, (long long)sid, r, ERR_reason_error_string(e));
                             /* Don't advance offsets for the partial vec; let nghttp3 retry/adjust. */


### PR DESCRIPTION
> **⚠️ Still in progress — posting early for visibility, not as a finished/verified fix.**
>
> We have **not** been able to reproduce this deterministically with a test harness (see
> *Reproduction* below for why we believe that's inherent to the bug). What we *do* have is a
> clear source-level explanation, a patch that compiles cleanly against the current `main`, and a
> live-adjacent build carrying it. **We will report back** once the patched driver has run under
> real traffic long enough to say whether the flood is actually gone. Treat this as a diagnosis +
> proposed fix to sanity-check, not a merge-ready PR yet.

## Summary

Under HTTP/3, `h3_conn_write_step()` can call `SSL_write_ex2()` on a stream whose **write side is
already concluded** (we sent FIN). OpenSSL correctly rejects this with `SSL_ERROR_SSL` /
`ERR_GET_REASON() == SSL_R_STREAM_FINISHED` (reason **365**). The write loop has explicit handlers
for `SSL_R_STREAM_RESET`, `SSL_R_STREAM_SEND_ONLY` and `SSL_R_PROTOCOL_IS_SHUTDOWN`, but **not** for
`SSL_R_STREAM_FINISHED`. So it falls through to the generic tail:

```c
Ns_Log(Error, "[%lld] H3[%lld] SSL_write_ex2: reason=%d (%s)", ...);
/* Don't advance offsets for the partial vec; let nghttp3 retry/adjust. */
return NS_TRUE; /* be conservative: schedule another pass */
```

`return NS_TRUE` reschedules the driver, the same stream is still write-armed with the same pending
vec, `SSL_write_ex2()` fails **identically** with 365 again, logs again, reschedules again — a tight
busy-loop. It only ends when the connection is finally reclaimed (for us, `connidletimeout`).

On our production box this manifested as bursts of:

```
[-driver:quic:h3-] Error: [NNNNN] H3[0] SSL_write_ex2: reason=365 (stream finished)
```

writing at **~23 MB/s** — a **60 GB** log file, and CPU burned on the spin for the life of the
stuck connection.

## Where and why the stream is already finished

The `SSL_R_STREAM_FINISHED` return is *correct* OpenSSL behaviour — the bug is that the driver
re-enters the write path for a stream it already concluded. Our leading hypothesis for how that
happens (offered for review; we have not instrumented it to certainty):

The response body for a large object (`>= writersize`, 131072 by default) is drained via the
shared writer-buffer path (`Shared*` in `shared.c`/`chunk.c`). The main loop attaches FIN and
concludes the stream when **nghttp3 signals `fin`**:

```c
/* Attach FIN after all vecs (only for bidi data streams). */
if (fin && StreamCtxIsBidi(sc) && !H3_IO_HAS(sc, H3_IO_TX_FIN)) {
    ...
    ok = SSL_stream_conclude(stream, 0);
    if (ok == 1) sc->io_state |= H3_IO_TX_FIN;
    ...
}
```

but the per-stream write decision keeps the stream write-armed while the app still has queued tx:

```c
} else if (hit_want || SharedTxReadable(&sc->sh)) {
    PollsetEnableWrite(dc, stream, sc, "after_sid");
    any_keep_w = NS_TRUE;
}
```

If `SharedTxReadable()` is still true at the moment of conclude (writer buffer not yet drained),
the stream stays armed, and the **next** `h3_conn_write_step()` pass tries to write the remaining
queued chunk onto the now-concluded stream → `SSL_R_STREAM_FINISHED`. Because that reason is
unhandled, we spin instead of tearing the write half down.

This also explains the observed shape: it is **bursty and correlated with large/`writersize`
media and with load**, not with any particular client action — consistent with an internal
timing race rather than a peer-driven event.

## The fix

Give `SSL_R_STREAM_FINISHED` the same "this stream's write half is done — stop, don't retry"
treatment the write loop already gives `SSL_R_STREAM_RESET`: tell nghttp3 to stop producing body,
mark FIN done, clear the error, drop write interest, and move to the next stream.

```diff
@@ h3_conn_write_step(), inside if (err == SSL_ERROR_SSL) { ... }
                             if (r == SSL_R_PROTOCOL_IS_SHUTDOWN) {
                                 /* Connection-level teardown - propagate and stop writing. */
                                 ...
                                 return NS_TRUE; /* writer should be scheduled to complete shutdown */
                             }
+
+                            if (r == SSL_R_STREAM_FINISHED) {
+                                /*
+                                 * The write side of this stream is already
+                                 * concluded (we sent FIN); OpenSSL correctly
+                                 * refuses further writes with STREAM_FINISHED.
+                                 * Returning NS_TRUE here would reschedule the
+                                 * SAME doomed write and re-fail identically on
+                                 * every poll iteration -- a tight Error-log flood
+                                 * (the "SSL_write_ex2: reason=365" storm, ~23 MB/s)
+                                 * that only stops when the connection is reclaimed.
+                                 * Treat it as terminal for this stream's write half:
+                                 * stop nghttp3 producing more body, mark FIN done,
+                                 * drop write interest, and move to the next stream.
+                                 */
+                                Ns_Log(Debug, "[%lld] H3[%lld] write on already-finished"
+                                       " stream; dropping write interest",
+                                       (long long)dc->iter, (long long)sid);
+                                nghttp3_conn_shutdown_stream_write(cc->h3conn, sid);
+                                sc->io_state |= H3_IO_TX_FIN;
+                                ERR_clear_error();
+                                (void)SSL_handle_events(stream);
+                                PollsetDisableWrite(dc, stream, sc,
+                                       "h3_conn_write_step SSL_R_STREAM_FINISHED");
+                                goto next_sid;
+                            }
+
                             Ns_Log(Error, "[%lld] H3[%lld] SSL_write_ex2: reason=%d (%s)",
```

It is purely additive: it intercepts a reason code that was previously unhandled. Every other
write-path outcome is untouched, so it cannot regress a healthy transfer — the worst case if our
race hypothesis is wrong is simply that this branch never fires.

Open question for maintainers: the **deeper** fix may be to *not keep the stream write-armed once
it has been concluded* (i.e. clear `SharedTxReadable`/write interest at conclude time, or gate the
`after_sid` re-arm on `!(sc->io_state & H3_IO_TX_FIN)`), so the doomed write is never attempted.
The patch above is the defensive backstop; the two are complementary.

## Reproduction — and why we can't script it

We could **not** trigger `SSL_R_STREAM_FINISHED` from a network client, and we now think that is
inherent: **no peer action produces it.** A client `RESET_STREAM` / `STOP_SENDING` surfaces as
`SSL_R_STREAM_RESET` (already handled); `STREAM_FINISHED` is strictly *self-inflicted* — it only
occurs when the server writes to a stream **it** already concluded. So it's an internal
writer-thread-vs-conclude timing race, which is why it appears in bursts under real traffic and
resists a deterministic harness.

What we tried (all against a live build; aioquic 1.3.0 client), watching the server's
`grep -c "SSL_write_ex2: reason=365"` counter:

| attempt | result |
|---|---|
| `h3stress.py abort multiplex churn --conc 6 --rounds 2` | counter +0 |
| `h3stress.py huge range abort multiplex --conc 20 --rounds 3` | counter +0 |
| targeted "many huge streams multiplexed on one conn + mid-flight `stop_sending`/`reset_stream`, small flow-control window for backpressure" | counter +0 |

The counter only ever advanced during **organic** traffic (and a large batch of it accumulated
during an unrelated server outage when many requests were returning `500` over h3). If a
maintainer can suggest a way to force the writer-buffer-still-full-at-conclude window
deterministically, we'll gladly add a regression test.

Validation plan instead: run the patched `quic.so` and watch whether the `reason=365` counter
grows under sustained real + synthetic (`h3stress.py`, full suite, high concurrency) load. We'll
post the before/after here.

## Environment

- NaviServer `main` (this `quic.c` matches current upstream in this area).
- Tcl 9.1, `nghttp3`, **OpenSSL 4.0.1** (`SSL_R_STREAM_FINISHED == 365` in `openssl/sslerr.h`;
  same value on 4.1.0-dev/master).
- 2-core Ubuntu 26.04, systemd-managed, `writerthreads 4` / `writersize 131072`.

## Relationship to prior work

Same driver and same file as the recent quic PRs (#23–#26: pollset/stream lifetime, driver thread
naming, OSB/OSU poll interest, idle reclamation). This is a separate, single-topic change per the
one-PR-per-topic preference. It touches only `h3_conn_write_step()`; it does not conflict with
those (no overlap with `PollsetSweep()` / the prototype block).
