### PR TITLE
quic: fix use-after-free in the h3 poll loop (dangling SSL left in the pollset after teardown)

### DIFF
--- a/quic/quic.c
+++ b/quic/quic.c
@@ -5484,6 +5484,35 @@ static void
 ConnCtxFree(ConnCtx *cc)
 {
     Ns_Log(Notice, "[%lld] H3 ConnCtxFree for cc %p", (long long)cc->dc->iter, (void*)cc);
+    /* ^^^ existing ConnCtxFree code (the diagnostic log) is unchanged. */
+
+    /* ===================================================================== *
+     * >>> NEW in this change: defensive pollset removal (reap UAF fix). >>>  *
+     *                                                                        *
+     * Everything from here to the matching "<<< end new" marker is added by  *
+     * this patch; the code above and below it is pre-existing and untouched. *
+     *                                                                        *
+     * Symmetric with the StreamCtxFree() block: guarantees the connection's  *
+     * SSL cannot be left in dc->u.h3.ssl_items[] after SSL_free() on a        *
+     * teardown path that skipped PollsetMarkDead(). No-op on the normal path  *
+     * (quic_conn_enter_shutdown() already marked it dead -> pidx == -1), and  *
+     * the "== cc->h3ssl.conn" check avoids clobbering a slot reused by        *
+     * another SSL.                                                            *
+     * ===================================================================== */
+    if (cc->pidx != (size_t)-1) {
+        NsTLSConfig *dc = cc->dc;
+        if (dc != NULL
+            && cc->pidx <= dc->u.h3.npoll
+            && (SSL *)dc->u.h3.ssl_items.data[cc->pidx] == cc->h3ssl.conn) {
+            dc->u.h3.ssl_items.data[cc->pidx]    = NULL;
+            dc->u.h3.poll_items[cc->pidx].events = 0;
+            if (dc->u.h3.first_dead == 0 || cc->pidx < dc->u.h3.first_dead) {
+                dc->u.h3.first_dead = cc->pidx;
+            }
+        }
+        cc->pidx = (size_t)-1;
+    }
+    /* <<< end new (reap UAF fix). Existing teardown code resumes: <<< */
 
     Tcl_DeleteHashTable(&cc->streams);
     SharedStateDestroy(&cc->shared);
@@ -5562,6 +5591,42 @@ static void StreamCtxFree(StreamCtx *sc)
            (long long)sc->quic_sid, (void*)sc, H3StreamKind_str(sc->kind), (void*)sc->rx_hold,
            sc->tx_queued.unread, sc->tx_pending.unread,
            sc->tx_queued.drained, sc->tx_pending.drained);
+    /* ^^^ existing StreamCtxFree code (the diagnostic log) is unchanged. */
+
+    /* ===================================================================== *
+     * >>> NEW in this change: defensive pollset removal (reap UAF fix). >>>  *
+     *                                                                        *
+     * Everything from here to the matching "<<< end new" marker is added by  *
+     * this patch; the code above and below it is pre-existing and untouched. *
+     *                                                                        *
+     * StreamCtxFree() runs from OpenSSL's ex_data free callback during       *
+     * SSL_free(stream), so it is the ONE place every stream teardown funnels *
+     * through. If some path freed this stream's SSL without first calling    *
+     * PollsetMarkDead() (e.g. the server-uni cleanup_err path SSL_free()s    *
+     * cstream/pstream/rstream directly), the driver pollset                  *
+     * (dc->u.h3.ssl_items[]) would keep a dangling SSL* whose StreamCtx is   *
+     * now freed; the next SSL_poll() result loop then does                   *
+     * sc = SSL_get_ex_data(dead_ssl, sc_idx); cc = sc->cc; -> use-after-free *
+     * (quic.c ~7540), crashing SIGSEGV or SIGILL. Punch the slot NULL here   *
+     * so the loop's "if (s != NULL)" guard skips it. Idempotent:             *
+     * PollsetMarkDead sets pidx = -1, and the "== sc->ssl" check avoids      *
+     * clobbering a slot that was already reused by another SSL.              *
+     * ===================================================================== */
+    if (sc->cc != NULL && sc->pidx != (size_t)-1) {
+        NsTLSConfig *dc = sc->cc->dc;
+        if (dc != NULL
+            && sc->pidx <= dc->u.h3.npoll
+            && (SSL *)dc->u.h3.ssl_items.data[sc->pidx] == sc->ssl) {
+            dc->u.h3.ssl_items.data[sc->pidx]    = NULL;
+            dc->u.h3.poll_items[sc->pidx].events = 0;
+            if (dc->u.h3.first_dead == 0 || sc->pidx < dc->u.h3.first_dead) {
+                dc->u.h3.first_dead = sc->pidx;
+            }
+        }
+        sc->pidx = (size_t)-1;
+    }
+    /* <<< end new (reap UAF fix). Existing resource-free code resumes: <<< */
+
     ns_free_const(sc->method);
     ns_free_const(sc->path);
     ns_free_const(sc->authority);


### PR DESCRIPTION

> **Status: we believe we've found and fixed this — filing now, confirming over the next few days.**
>
> Gustaf — we think we've pinned this one down and solved it. The fix is already deployed on the
> production server that was reproducing the crash (it was dumping core several times a day), and
> we're opening the PR now so you can review the reasoning while it soaks. We'd like to let it run a
> few more days before we call it *confirmed*, and we'll report the before/after crash numbers back
> in this thread. Posting early rather than sitting on it, because the diagnosis below is concrete
> and the fix is small and self-contained.

## The bug, in one paragraph

It's a **use-after-free**: a stream/connection is freed by the reap/teardown path, but its
`SSL *s` is still sitting in the poll array (`dc->u.h3.ssl_items`). So the next `SSL_poll()`
iteration pulls the stale `s`, `SSL_get_ex_data(s, sc_idx)` hands back a **dangling `StreamCtx`**,
and `sc->cc` dereferences freed memory → **SIGSEGV** when the page is unmapped, **SIGILL / garbage**
when it's already been reallocated. (That varying signal is exactly how you know it's a UAF and not
a plain null-deref.) The crash is at **`quic.c`, `QuicThread()`**, in the poll-result loop:

```c
for (i = 0; i < (int)numitems; i++) {
    SSL *s = dc->u.h3.ssl_items.data[i];
    ...
    if (s != NULL) {
        sc = SSL_get_ex_data(s, dc->u.h3.sc_idx);   /* s is freed → sc is dangling */
        if (sc != NULL) {
            cc = sc->cc;                             /* ← fault */
```

## How we found it

We first hit an unrelated `SSL_write_ex2: reason=365` log flood (submitted separately as a WIP PR);
while watching that server we noticed `nsd` was also **dumping core several times a day** — SIGSEGV,
SIGILL and SIGBUS intermixed. Mixed fatal signals from the same workload is the classic fingerprint
of memory corruption, so we captured backtraces:

1. **Enabled real cores.** The box was routing cores through `apport`, which `coredumpctl` can't
   read. Installed `systemd-coredump` and raised `ProcessSizeMax`/`ExternalSizeMax` to 8 G (nsd runs
   ~6 G RSS, so the default 1 G cap would truncate the stack). `quic.so` is built `-g`.
2. **Caught three crashes** (1×SIGSEGV, 2×SIGILL). Every one had the same crashing thread:
   ```
   #2  ReraiseFatalSignal   (libnsd.so)     ← NaviServer's fatal-signal handler
   #3  Abort                (libnsd.so)
   #4  __restore_rt                          ← original fault delivered here
   #5  QuicThread           (quic.so + 0xdac0)
   #6  NsThreadMain
   ```
   i.e. the real fault is inside `QuicThread`; NaviServer's handler caught it and re-raised to dump.
3. **Resolved the address.** At `-O2` the poll loop is all inlined into `QuicThread`, so the frame
   collapses to one symbol. `addr2line -f -i -e quic.so 0xdac0` →
   **`QuicThread` / `quic.c:7540`** — the `sc = SSL_get_ex_data(...); cc = sc->cc;` above. Two of the
   three cores resolved to the identical line.
4. **Traced the lifetime.** `StreamCtx` and `ConnCtx` are owned by their `SSL` via ex_data: OpenSSL
   calls `ossl_sc_exdata_free → StreamCtxFree` / `ossl_cc_exdata_free → ConnCtxFree` from inside
   `SSL_free()`. So the `StreamCtx` behind a slot is freed **exactly** when that slot's `SSL` is
   freed. For the loop to deref a freed `StreamCtx`, the invariant *"an `SSL` in the pollset is
   always live"* must be broken — i.e. **some path freed an `SSL` without first removing it from the
   pollset.**
5. **Found a concrete violator.** `PollsetMarkDead()` is what NULLs a slot (and it sets `pidx = -1`),
   and the mainline teardown (`quic_conn_enter_shutdown` → `PollsetReapConnStreams` → `PollsetMarkDead`
   → `SSL_free`) is correct. But the server-uni setup error path (`cleanup_err`) does
   `SSL_free(cstream/pstream/rstream)` after only `StreamCtxUnregister()` (which just drops the hash
   entry) — **no `PollsetMarkDead`.** Those streams were already added to the pollset via
   `PollsetAddStreamRegister`, so their slots are left dangling. Any similar path has the same effect.

## The fix

Rather than chase every one of the ~8 `SSL_free` sites, enforce the invariant at the **single place
every teardown funnels through** — the ex_data free callbacks. `StreamCtxFree()` and `ConnCtxFree()`
run from inside `SSL_free()` no matter which path triggered it, so clearing the pollset slot there is
a guaranteed backstop:

```c
/* in StreamCtxFree(sc), before releasing sc's memory */
if (sc->cc != NULL && sc->pidx != (size_t)-1) {
    NsTLSConfig *dc = sc->cc->dc;
    if (dc != NULL
        && sc->pidx <= dc->u.h3.npoll
        && (SSL *)dc->u.h3.ssl_items.data[sc->pidx] == sc->ssl) {
        dc->u.h3.ssl_items.data[sc->pidx]    = NULL;
        dc->u.h3.poll_items[sc->pidx].events = 0;
        if (dc->u.h3.first_dead == 0 || sc->pidx < dc->u.h3.first_dead) {
            dc->u.h3.first_dead = sc->pidx;
        }
    }
    sc->pidx = (size_t)-1;
}
```

and the symmetric block in `ConnCtxFree()` using `cc->pidx` / `cc->h3ssl.conn`.

Why this is safe and correct:
- **Idempotent.** The mainline path already calls `PollsetMarkDead()`, which sets `pidx = -1`; this
  block then does nothing. It only acts when a slot was left behind.
- **Can't clobber a reused slot.** The `ssl_items.data[pidx] == sc->ssl` guard means it only NULLs
  the slot if it still points at *this* SSL.
- **Same thread.** `SSL_free()` is only ever called from `QuicThread`, which owns the pollset, so
  touching `ssl_items`/`poll_items` here needs no extra locking — it's exactly what
  `PollsetMarkDead()` already does.
- **Reuses existing bookkeeping** (`pidx` backref, `first_dead`), matching `PollsetMarkDead()`.

The alternative — adding `PollsetMarkDead()` to `cleanup_err` (and auditing every other free site) —
also works and is arguably more local; we chose the choke-point because it closes the whole class in
two spots and is self-documenting. Happy to switch to the per-site approach if maintainers prefer.

## How it was tested

- **Builds clean** against the current tree (`-g -O2 -Wall -Wextra -Wconversion …`), no new warnings.
- **No functional regression:** the full h3 client suite (aioquic 1.3.0 — small/large/range/multiplex/
  churn/abort/idle, concurrency 8–20) passes 100% after the change, HTTP/2 canary stays 200, nsd pid
  stable across the run.
- **Live soak (in progress):** deployed to the production server that was reproducing the crash. Before
  the fix, `nsd` dumped core **several times a day**, all resolving to `quic.c:7540`. After the fix we
  are watching `coredumpctl` for any new dump; **we'll report the before/after here** once it has run
  long enough to be conclusive. (We can't offer a scripted repro: the trigger is an internal
  teardown-vs-poll timing race, not anything a client can drive on demand — same reason the sibling
  reason=365 issue isn't client-reproducible.)

## Environment

NaviServer `main`; Tcl 9.1, `nghttp3`, OpenSSL 4.0.1; 2-core Ubuntu 26.04, systemd, `writerthreads 4`.

## Relationship to prior work

Same driver/file and the same pollset-lifetime area as the recent quic PRs (#23–#26 stream/pollset
lifetime, #27 the reason=365 write-loop flood). This is a distinct, single-topic change: it touches
only `StreamCtxFree()` and `ConnCtxFree()`.
